### PR TITLE
Fix rank up and down params incorrect

### DIFF
--- a/scripting/include/tfgungame.inc
+++ b/scripting/include/tfgungame.inc
@@ -50,8 +50,8 @@ methodmap GGWeapon < ArrayList
 };
 
 forward void OnGunGameWin(int client);
-forward void OnGunGameRankUp(int attacker, int victim, int rank, GGWeapon weapon, GGWeapon oldweapon);
-forward void OnGunGameRankDown(int attacker, int victim, int rank, GGWeapon weapon, GGWeapon oldweapon);
+forward void OnGunGameRankUp(int attacker, int victim, int rank, GGWeapon oldweapon, GGWeapon weapon);
+forward void OnGunGameRankDown(int attacker, int victim, int rank, GGWeapon oldweapon, GGWeapon weapon);
 
 native int GetGunGameRank(int client);
 native void ForceGunGameWin(int client);

--- a/scripting/tfgungame.sp
+++ b/scripting/tfgungame.sp
@@ -579,13 +579,16 @@ public Action OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
 		g_hCvarHumiliationSound.GetString(strSound, sizeof(strSound));
 		EmitSoundToAll(strSound, .level = SNDLEVEL_ROCKET);
 		
-		Call_StartForward(hFwdRankDown);
-		Call_PushCell(iAttacker);
-		Call_PushCell(iVictim);
-		Call_PushCell(g_PlayerData[iVictim].Rank);
-		Call_PushCell(GGWeapon.GetFromSeries(g_PlayerData[iVictim].Rank));
-		Call_PushCell(GGWeapon.GetFromSeries(g_PlayerData[iVictim].Rank + 1));
-		Call_Finish();
+		if (g_PlayerData[iVictim].Rank > 0)
+		{
+			Call_StartForward(hFwdRankDown);
+			Call_PushCell(iAttacker);
+			Call_PushCell(iVictim);
+			Call_PushCell(g_PlayerData[iVictim].Rank);
+			Call_PushCell(GGWeapon.GetFromSeries(g_PlayerData[iVictim].Rank));
+			Call_PushCell(GGWeapon.GetFromSeries(g_PlayerData[iVictim].Rank - 1));
+			Call_Finish();
+		}
 	}
 
 	return Plugin_Continue;


### PR DESCRIPTION
In `OnGunGameRankUp`, `weapon` and `oldweapon` was swapped the wrong way round. Just rename the param and keep the functionality the same as it is.

Swap in `OnGunGameRankDown` aswell, but also pass `weapon` as an actual weapon client will have on rank down instead of on rank up