### PR TITLE
Remove MvM entities from clean list

### DIFF
--- a/scripting/tfgungame.sp
+++ b/scripting/tfgungame.sp
@@ -32,12 +32,10 @@ stock const char WIN_SOUND[] = ""; // TODO
 stock const char HUMILIATION_SOUND[] = ""; // TODO
 stock const char strCleanTheseEntities[][256] = 
 {
-	"info_populator",
 	"info_passtime_ball_spawn",
 	"tf_logic_arena",
 	"tf_logic_hybrid_ctf_cp",
 	"tf_logic_koth",
-	"tf_logic_mann_vs_machine",
 	"tf_logic_medieval",
 	"tf_logic_multiple_escort",
 	"tf_logic_player_destruction",


### PR DESCRIPTION
These entities will crash the server if removed too early, because pointers to them are still being accessed everywhere

GunGame maps don't use these anyway (and would crash if they did) so it's safe to just not bother with them