### PR TITLE
Mark GetGunGamePlacements native as optional

### DIFF
--- a/scripting/include/tfgungame.inc
+++ b/scripting/include/tfgungame.inc
@@ -96,6 +96,7 @@ public __pl_tfgungame_SetNTVOptional()
 	MarkNativeAsOptional("GGWeapon.Disabled.get");
 	MarkNativeAsOptional("GGWeapon.ClipOverride.get");
 	
+	MarkNativeAsOptional("GetGunGamePlacements");
 	MarkNativeAsOptional("GetGunGameRank");
 	MarkNativeAsOptional("ForceGunGameWin");
 	MarkNativeAsOptional("ForceGunGameRank");


### PR DESCRIPTION
Something I missed when adding the native a while ago.